### PR TITLE
show hidden packages in the search

### DIFF
--- a/cheeseprism/rpc.py
+++ b/cheeseprism/rpc.py
@@ -30,7 +30,8 @@ class PyPi(object):
     @classmethod
     def search(cls, package_name):
         client = xmlrpclib.ServerProxy(cls.index)
-        return client.package_releases(package_name)
+        show_hidden = True
+        return client.package_releases(package_name, show_hidden)
 
     ### for additional information
     @classmethod


### PR DESCRIPTION
This will list hidden packages on the search page. Very useful when you don't necessarily want to download the latest version of a given package.
