### PR TITLE
Create 'cheeseprism.on_upload' callback entry point

### DIFF
--- a/cheeseprism/views.py
+++ b/cheeseprism/views.py
@@ -14,6 +14,7 @@ from urllib2 import HTTPError
 from urllib2 import URLError
 from webob import exc
 import logging
+import pkg_resources
 import requests
 import tempfile
 
@@ -69,6 +70,12 @@ def upload(context, request):
             try:
                 request.registry.notify(event.PackageAdded(request.index, path=dest))
                 request.response.headers['X-Swalow-Status'] = 'SUCCESS'
+                try:
+                    for ep in pkg_resources.iter_entry_points('cheeseprism.on_upload'):
+                        func = ep.load()
+                        func(context, request, dest)
+                except Exception as e:
+                    logger.exception('Entry point %r failed', ep)
                 return request.response
             except :
                 logger.exception("Processing of %s failed", filename)


### PR DESCRIPTION
This gets called post-upload and allows folks to write upload handlers to do stuff like upload the newly uploaded package to another repository like devpi (which is the exact use case that I have in mind).

Cc: @sudarkoff, @aconrad