### PR TITLE
Allow import of wheel-only distribution from PyPI

### DIFF
--- a/cheeseprism/index.py
+++ b/cheeseprism/index.py
@@ -33,7 +33,7 @@ class IndexManager(object):
     """
 
     root_index_file = 'index.html'
-    EXTS = re.compile(r'^.*(?P<ext>\.egg|\.gz|\.bz2|\.tgz|\.zip)$')
+    EXTS = re.compile(r'^.*(?P<ext>\.egg|\.whl|\.gz|\.bz2|\.tgz|\.zip)$')
     SDIST_EXT = re.compile(r'^.*(?P<ext>\.gz|\.bz2|\.tgz|\.zip)$')
 
     leaf_name = 'leaf.html'

--- a/cheeseprism/views.py
+++ b/cheeseprism/views.py
@@ -107,7 +107,7 @@ def from_pypi(request, fpkgs='/find-packages'):
         flash("%s-%s not found" %(name, version))
         return HTTPFound(fpkgs)
 
-    candidates = [x for x in dists if request.index.SDIST_EXT.match(x['filename'])]
+    candidates = [x for x in dists if request.index.EXTS.match(x['filename'])]
 
     if candidates[0]['md5_digest'] in request.index_data:
         logger.debug('Package %s-%s already in index' %(name, version))


### PR DESCRIPTION
Without this, we get the following when trying to import [h2o from PyPI](https://pypi.python.org/pypi/h2o/3.2.0.3):

    2015-09-24 11:12:44,781 ERROR [waitress] Exception when serving /package/h2o/3.2.0.3
    Traceback (most recent call last):
      ...
      File "/opt/prism/src/cheeseprism/cheeseprism/views.py", line 118, in from_pypi
        if candidates[0]['md5_digest'] in request.index_data:
    IndexError: list index out of range

Cc: @whitmo, @sudarkoff, @BenoitDherin, @bszonye

Fixes: DEVOPS-766 at The Monkey.