### PR TITLE
Use HTTPS for talking to PyPI

### DIFF
--- a/cheeseprism/pipext.py
+++ b/cheeseprism/pipext.py
@@ -169,7 +169,7 @@ class RequirementDownloader(object):
         return pkginfo, outfile, req_set,
 
     pkg_finder_class = PackageFinder
-    index_urls = ['http://pypi.python.org/simple']
+    index_urls = ['https://pypi.python.org/simple']
 
     def download_all(self, req_set=None, finder=None):
         if req_set is None:

--- a/cheeseprism/rpc.py
+++ b/cheeseprism/rpc.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class PyPi(object):
-    index = 'http://pypi.python.org/pypi'
+    index = 'https://pypi.python.org/pypi'
     pkglist = None
     timeout = 5 * 60
 

--- a/tests/test_pipext.py
+++ b/tests/test_pipext.py
@@ -103,7 +103,7 @@ class TestReqDownloader(PipExtBase):
         pf = pipext.RequirementDownloader.package_finder
         finder = pf(deplinks=['a deplink'], index_urls=['an index_url'])
         assert finder.dependency_links == ['a deplink']
-        assert finder.index_urls == ['http://pypi.python.org/simple', 'an index_url']
+        assert finder.index_urls == ['https://pypi.python.org/simple', 'an index_url']
 
 
 class ZFMock(Mock):


### PR DESCRIPTION
because PyPI requires it now; otherwise you get:

``` pytb
  File "/opt/prism/local/lib/python2.7/site-packages/pyramid/config/views.py", line 348, in rendered_view
    result = view(context, request)
  File "/opt/prism/src/cheeseprism/cheeseprism/views.py", line 93, in find_package
    releases = PyPi.search(search_term)
  File "/opt/prism/src/cheeseprism/cheeseprism/rpc.py", line 34, in search
    return client.package_releases(package_name, show_hidden)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1233, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1587, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/xmlrpclib.py", line 1273, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1321, in single_request
    response.msg,
ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>
```
